### PR TITLE
Refactor 2024

### DIFF
--- a/count_test.go
+++ b/count_test.go
@@ -31,7 +31,7 @@ func TestAlive(t *testing.T) {
 		timer := time.After(5 * time.Second)
 		select {
 		case <-timer:
-			t.Fatal("no AliveCellsCount events received in 5 seconds")
+			panic("No AliveCellsCount events received in 5 seconds")
 		case <-implemented:
 			return
 		}
@@ -65,7 +65,7 @@ func TestAlive(t *testing.T) {
 			return
 		}
 	}
-	t.Fatal("not enough AliveCellsCount events received")
+	t.Fatal("Not enough AliveCellsCount events received")
 }
 
 func readAliveCounts(width, height int) map[int]int {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module uk.ac.bris.cs/gameoflife
 
-go 1.12
+go 1.21
 
-require github.com/veandco/go-sdl2 v0.4.4
+require github.com/veandco/go-sdl2 v0.4.38

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/veandco/go-sdl2 v0.4.4 h1:coOJGftOdvNvGoUIZmm4XD+ZRQF4mg9ZVHmH3/42zFQ=
-github.com/veandco/go-sdl2 v0.4.4/go.mod h1:FB+kTpX9YTE+urhYiClnRzpOXbiWgaU3+5F2AB78DPg=
+github.com/veandco/go-sdl2 v0.4.38 h1:lx8syOA2ccXlgViYkQe2Kn/4xt+p9mdd1Qc/yYMrmSo=
+github.com/veandco/go-sdl2 v0.4.38/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=

--- a/gol/event.go
+++ b/gol/event.go
@@ -14,14 +14,14 @@ type Event interface {
 	GetCompletedTurns() int
 }
 
-// AliveCellsCount is an Event notifying the user about the number of currently alive cells.
+// `AliveCellsCount` is an Event notifying the user about the number of currently alive cells.
 // This Event should be sent every 2s.
 type AliveCellsCount struct { // implements Event
 	CompletedTurns int
 	CellsCount     int
 }
 
-// ImageOutputComplete is an Event notifying the user about the completion of output.
+// `ImageOutputComplete` is an Event notifying the user about the completion of output.
 // This Event should be sent every time an image has been saved.
 type ImageOutputComplete struct { // implements Event
 	CompletedTurns int
@@ -37,29 +37,39 @@ const (
 	Quitting
 )
 
-// StateChange is an Event notifying the user about the change of state of execution.
+// `StateChange` is an Event notifying the user about the change of state of execution.
 // This Event should be sent every time the execution is paused, resumed or quit.
 type StateChange struct { // implements Event
 	CompletedTurns int
 	NewState       State
 }
 
-// CellFlipped is an Event notifying the GUI about a change of state of a single cell.
-// This even should be sent every time a cell changes state.
+// `CellFlipped` is an Event notifying the GUI about a change of state of a single cell.
+// This event should be sent every time a cell changes state.
 // Make sure to send this event for all cells that are alive when the image is loaded in.
 type CellFlipped struct { // implements Event
 	CompletedTurns int
 	Cell           util.Cell
 }
 
-// TurnComplete is an Event notifying the GUI about turn completion.
+// `CellsFlipped` is an Event notifying the GUI about a change of state of many cells.
+// You can collect many flipped cells and send `CellsFlipped` at a time instead of sending `CellFlipped` for every flipped cell.
+// You can send many times of `CellsFlipped` event in a turn, i.e., each worker could send `CellsFlipped`.
+// **Please be careful not to send `CellFlipped` and `CellsFlipped` at the same time, as they may conflict.**
+// Choose one of them.
+type CellsFlipped struct { // implements Event
+	CompletedTurns int
+	Cells   []util.Cell
+}
+
+// `TurnComplete` is an Event notifying the GUI about turn completion.
 // SDL will render a frame when this event is sent.
-// All CellFlipped events must be sent *before* TurnComplete.
+// All `CellFlipped` or `CellsFlipped` events must be sent *before* `TurnComplete`.
 type TurnComplete struct { // implements Event
 	CompletedTurns int
 }
 
-// FinalTurnComplete is an Event notifying the testing framework about the new world state after execution finished.
+// `FinalTurnComplete` is an Event notifying the testing framework about the new world state after execution finished.
 // The data included with this Event is used directly by the tests.
 // SDL closes the window when this Event is sent.
 type FinalTurnComplete struct {
@@ -99,7 +109,7 @@ func (event AliveCellsCount) GetCompletedTurns() int {
 }
 
 func (event ImageOutputComplete) String() string {
-	return fmt.Sprintf("File %v output complete", event.Filename)
+	return fmt.Sprintf("File %v Output Done", event.Filename)
 }
 
 func (event ImageOutputComplete) GetCompletedTurns() int {
@@ -107,15 +117,23 @@ func (event ImageOutputComplete) GetCompletedTurns() int {
 }
 
 func (event CellFlipped) String() string {
-	return fmt.Sprintf("")
+	return ""
 }
 
 func (event CellFlipped) GetCompletedTurns() int {
 	return event.CompletedTurns
 }
 
+func (event CellsFlipped) String() string {
+	return ""
+}
+
+func (event CellsFlipped) GetCompletedTurns() int {
+	return event.CompletedTurns
+}
+
 func (event TurnComplete) String() string {
-	return fmt.Sprintf("")
+	return ""
 }
 
 func (event TurnComplete) GetCompletedTurns() int {
@@ -123,7 +141,7 @@ func (event TurnComplete) GetCompletedTurns() int {
 }
 
 func (event FinalTurnComplete) String() string {
-	return fmt.Sprintf("")
+	return "Final Turn Complete"
 }
 
 func (event FinalTurnComplete) GetCompletedTurns() int {

--- a/gol/io.go
+++ b/gol/io.go
@@ -2,7 +2,6 @@ package gol
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -92,7 +91,7 @@ func (io *ioState) readPgmImage() {
 	// Request a filename from the distributor.
 	filename := <-io.channels.filename
 
-	data, ioError := ioutil.ReadFile("images/" + filename + ".pgm")
+	data, ioError := os.ReadFile("images/" + filename + ".pgm")
 	util.Check(ioError)
 
 	fields := strings.Fields(string(data))
@@ -132,18 +131,15 @@ func startIo(p Params, c ioChannels) {
 		channels: c,
 	}
 
-	for {
-		select {
+	for command := range io.channels.command {
 		// Block and wait for requests from the distributor
-		case command := <-io.channels.command:
-			switch command {
-			case ioInput:
-				io.readPgmImage()
-			case ioOutput:
-				io.writePgmImage()
-			case ioCheckIdle:
-				io.channels.idle <- true
-			}
+		switch command {
+		case ioInput:
+			io.readPgmImage()
+		case ioOutput:
+			io.writePgmImage()
+		case ioCheckIdle:
+			io.channels.idle <- true
 		}
 	}
 }

--- a/gol_test.go
+++ b/gol_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -86,7 +86,7 @@ func assertEqualBoard(t *testing.T, given, expected []util.Cell, p gol.Params) b
 }
 
 func readAliveCells(path string, width, height int) []util.Cell {
-	data, ioError := ioutil.ReadFile(path)
+	data, ioError := os.ReadFile(path)
 	util.Check(ioError)
 
 	fields := strings.Fields(string(data))

--- a/main.go
+++ b/main.go
@@ -38,22 +38,23 @@ func main() {
 		10000000000,
 		"Specify the number of turns to process. Defaults to 10000000000.")
 
-	noVis := flag.Bool(
-		"noVis",
+	headless := flag.Bool(
+		"headless",
 		false,
-		"Disables the SDL window, so there is no visualisation during the tests.")
+		"Disable the SDL window for running in a headless environment.")
 
 	flag.Parse()
 
-	fmt.Println("Threads:", params.Threads)
-	fmt.Println("Width:", params.ImageWidth)
-	fmt.Println("Height:", params.ImageHeight)
+	fmt.Printf("%-10v %v\n", "Threads", params.Threads)
+	fmt.Printf("%-10v %v\n", "Width", params.ImageWidth)
+	fmt.Printf("%-10v %v\n", "Height", params.ImageHeight)
+	fmt.Printf("%-10v %v\n", "Turns", params.Turns)
 
 	keyPresses := make(chan rune, 10)
 	events := make(chan gol.Event, 1000)
 
 	go gol.Run(params, events, keyPresses)
-	if !(*noVis) {
+	if !(*headless) {
 		sdl.Run(params, events, keyPresses)
 	} else {
 		sdl.RunHeadless(events)

--- a/main.go
+++ b/main.go
@@ -56,13 +56,6 @@ func main() {
 	if !(*noVis) {
 		sdl.Run(params, events, keyPresses)
 	} else {
-		complete := false
-		for !complete {
-			event := <-events
-			switch event.(type) {
-			case gol.FinalTurnComplete:
-				complete = true
-			}
-		}
+		sdl.RunHeadless(events)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"runtime"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"uk.ac.bris.cs/gameoflife/gol"
 	"uk.ac.bris.cs/gameoflife/sdl"
@@ -53,10 +56,19 @@ func main() {
 	keyPresses := make(chan rune, 10)
 	events := make(chan gol.Event, 1000)
 
+	go sigterm(keyPresses)
+
 	go gol.Run(params, events, keyPresses)
 	if !(*headless) {
 		sdl.Run(params, events, keyPresses)
 	} else {
 		sdl.RunHeadless(events)
 	}
+}
+
+func sigterm(keyPresses chan<- rune) {
+	sigterm := make(chan os.Signal, 1)
+	signal.Notify(sigterm, syscall.SIGTERM, syscall.SIGINT)
+	<-sigterm
+	keyPresses <- 'q'
 }

--- a/sdl/loop.go
+++ b/sdl/loop.go
@@ -2,53 +2,94 @@ package sdl
 
 import (
 	"fmt"
+	"time"
 	"github.com/veandco/go-sdl2/sdl"
 	"uk.ac.bris.cs/gameoflife/gol"
+	"uk.ac.bris.cs/gameoflife/util"
 )
+
+const FPS = 60
 
 func Run(p gol.Params, events <-chan gol.Event, keyPresses chan<- rune) {
 	w := NewWindow(int32(p.ImageWidth), int32(p.ImageHeight))
+	defer w.Destroy()
+	dirty := false
+	refreshTicker := time.NewTicker(time.Second / time.Duration(FPS))
+	avgTurns := util.NewAvgTurns()
 
-sdlLoop:
+sdl:
 	for {
-		event := w.PollEvent()
-		if event != nil {
-			switch e := event.(type) {
-			case *sdl.KeyboardEvent:
-				switch e.Keysym.Sym {
-				case sdl.K_p:
-					keyPresses <- 'p'
-				case sdl.K_s:
-					keyPresses <- 's'
-				case sdl.K_q:
+		select {
+		case <-refreshTicker.C:
+			event := w.PollEvent()
+			if event != nil {
+				switch e := event.(type) {
+				case *sdl.QuitEvent:
 					keyPresses <- 'q'
-				case sdl.K_k:
-					keyPresses <- 'k'
+				case *sdl.KeyboardEvent:
+					switch e.Keysym.Sym {
+					case sdl.K_ESCAPE:
+						keyPresses <- 'q'
+					case sdl.K_p:
+						keyPresses <- 'p'
+					case sdl.K_s:
+						keyPresses <- 's'
+					case sdl.K_q:
+						keyPresses <- 'q'
+					case sdl.K_k:
+						keyPresses <- 'k'
+					}
 				}
 			}
-		}
-		select {
+			if dirty {
+				w.RenderFrame()
+				dirty = false
+			}
+
 		case event, ok := <-events:
 			if !ok {
-				w.Destroy()
-				break sdlLoop
+				break sdl
 			}
 			switch e := event.(type) {
 			case gol.CellFlipped:
 				w.FlipPixel(e.Cell.X, e.Cell.Y)
+			case gol.CellsFlipped:
+				for _, cell := range e.Cells {
+					w.FlipPixel(cell.X, cell.Y) 
+				}
 			case gol.TurnComplete:
-				w.RenderFrame()
+				dirty = true
+			case gol.AliveCellsCount:
+				fmt.Printf("Completed Turns %-8v %-20v Avg%+5v turns/sec\n", event.GetCompletedTurns(), event, avgTurns.Get(event.GetCompletedTurns()))
 			case gol.FinalTurnComplete:
-				w.Destroy()
-				break sdlLoop
-			default:
-				if len(event.String()) > 0 {
-					fmt.Printf("Completed Turns %-8v%v\n", event.GetCompletedTurns(), event)
+				fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+			case gol.ImageOutputComplete:
+				fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+			case gol.StateChange:
+				fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+				if e.NewState == gol.Quitting {
+					break sdl
 				}
 			}
-		default:
-			break
 		}
 	}
+}
 
+func RunHeadless(events <-chan gol.Event) {
+	avgTurns := util.NewAvgTurns()
+	for event := range events {
+		switch e := event.(type) {
+		case gol.AliveCellsCount:
+			fmt.Printf("Completed Turns %-8v %-20v Avg%+5v turns/sec\n", event.GetCompletedTurns(), event, avgTurns.Get(event.GetCompletedTurns()))
+		case gol.FinalTurnComplete:
+			fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), "Final Turn Complete")
+		case gol.ImageOutputComplete:
+			fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+		case gol.StateChange:
+			fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+			if e.NewState == gol.Quitting {
+				break
+			}
+		}
+	}
 }

--- a/sdl/window.go
+++ b/sdl/window.go
@@ -2,7 +2,8 @@ package sdl
 
 import (
 	"fmt"
-
+	"unsafe"
+	
 	"github.com/veandco/go-sdl2/sdl"
 	"uk.ac.bris.cs/gameoflife/util"
 )
@@ -54,7 +55,7 @@ func (w *Window) Destroy() {
 }
 
 func (w *Window) RenderFrame() {
-	err := w.texture.Update(nil, w.pixels, int(w.Width*4))
+	err := w.texture.Update(nil, unsafe.Pointer(&w.pixels[0]), int(w.Width*4))
 	util.Check(err)
 	err = w.renderer.Clear()
 	util.Check(err)

--- a/sdl_test.go
+++ b/sdl_test.go
@@ -10,119 +10,330 @@ import (
 
 	"uk.ac.bris.cs/gameoflife/gol"
 	"uk.ac.bris.cs/gameoflife/sdl"
+	"uk.ac.bris.cs/gameoflife/util"
 )
 
-var sdlEvents chan gol.Event
-var sdlAlive chan int
+var w *sdl.Window
+var refresh chan bool
 
 func TestMain(m *testing.M) {
 	runtime.LockOSThread()
-	noVis := flag.Bool("noVis", false,
-		"Disables the SDL window, so there is no visualisation during the tests.")
+	var sdlFlag = flag.Bool(
+		"sdl",
+		false,
+		"Enable the SDL window for testing.")
+
 	flag.Parse()
-	p := gol.Params{ImageWidth: 512, ImageHeight: 512}
-	sdlEvents = make(chan gol.Event)
-	sdlAlive = make(chan int)
-	result := make(chan int)
-	go func() {
-		res := m.Run()
-		go func() {
-			sdlEvents <- gol.FinalTurnComplete{}
-		}()
-		result <- res
-	}()
-	// sdl.Run(p, sdlEvents, nil)
-	var w *sdl.Window = nil
-	if !(*noVis) {
-		w = sdl.NewWindow(int32(p.ImageWidth), int32(p.ImageHeight))
-	}
-
-	board := make([][]byte, p.ImageHeight)
-	for i := 0; i < p.ImageHeight; i++ {
-		board[i] = make([]byte, p.ImageWidth)
-	}
-
-sdlLoop:
-	for {
-		w.PollEvent()
-		select {
-		case event, ok := <-sdlEvents:
-			if !ok {
-				if w != nil {
-					w.Destroy()
+	done := make(chan int, 1)
+	test := func() { done <- m.Run() }
+	if !(*sdlFlag) {
+		go test()
+	} else {
+		w = sdl.NewWindow(512, 512)
+		refresh = make(chan bool, 1)
+		fps := 60
+		ticker := time.NewTicker(time.Second / time.Duration(fps))
+		dirty := false
+		go test()
+	loop:
+		for {
+			select {
+			case code := <-done:
+				done <- code
+				w.Destroy()
+				break loop
+			case <-ticker.C:
+				w.PollEvent()
+				if dirty {
+					w.RenderFrame()
+					dirty = false
 				}
-				break sdlLoop
+			case <-refresh:
+				dirty = true
 			}
+		}
+	}
+	os.Exit(<-done)
+}
+
+// TestSdl tests key presses and events
+func TestSdl(t *testing.T) {
+	params := gol.Params{
+		Turns:       100000000,
+		Threads:     8,
+		ImageWidth:  512,
+		ImageHeight: 512,
+	}
+
+	keyPresses := make(chan rune, 10)
+	events := make(chan gol.Event, 1000)
+
+	golDone := make(chan bool, 1)
+	go func() {
+		gol.Run(params, events, keyPresses)
+		golDone <- true
+	}()
+	startTester(t, params, keyPresses, events, golDone)
+}
+
+type Tester struct {
+	t            *testing.T
+	params       gol.Params
+	keyPresses   chan<- rune
+	events       <-chan gol.Event
+	eventWatcher <-chan gol.Event
+	turn         int
+	world        [][]byte
+	aliveMap     map[int]int
+}
+
+func startTester(
+	t *testing.T,
+	params gol.Params,
+	keyPresses chan<- rune,
+	events <-chan gol.Event,
+	golDone <-chan bool,
+) {
+	world := make([][]byte, params.ImageHeight)
+	for i := range world {
+		world[i] = make([]byte, params.ImageWidth)
+	}
+
+	eventWatcher := make(chan gol.Event, 1000)
+	tester := Tester{
+		t:            t,
+		params:       params,
+		keyPresses:   keyPresses,
+		events:       events,
+		eventWatcher: eventWatcher,
+		turn:         0,
+		world:        world,
+		aliveMap:     readAliveCounts(params.ImageWidth, params.ImageHeight),
+	}
+
+	cancelDeadline := deadline(25*time.Second,
+		"Your program should complete this test within 20 seconds. Is your program deadlocked?")
+
+	go tester.testPause(3 * time.Second)
+	go tester.testOutput(12 * time.Second)
+	quitting := make(chan bool, 1)
+	go func() {
+		tester.testQuitting(16 * time.Second)
+		quitting <- true
+	}()
+
+	cellFlippedReceived := false
+	turnCompleteReceived := false
+
+	avgTurns := util.NewAvgTurns()
+
+loop:
+	for {
+		select {
+		case <-quitting:
+			if !cellFlippedReceived {
+				panic("No CellFlipped events received")
+			}
+			if !turnCompleteReceived {
+				panic("No TurnComplete events received")
+			}
+			<-golDone
+			cancelDeadline <- true
+			break loop
+		case event := <-tester.events:
 			switch e := event.(type) {
 			case gol.CellFlipped:
-				board[e.Cell.Y][e.Cell.X] = ^board[e.Cell.Y][e.Cell.X]
+				cellFlippedReceived = true
+				assert(e.CompletedTurns == tester.turn || e.CompletedTurns == tester.turn+1,
+					"Expected completed %v turns, got %v instead", tester.turn, e.CompletedTurns)
+				tester.world[e.Cell.Y][e.Cell.X] = ^tester.world[e.Cell.Y][e.Cell.X]
 				if w != nil {
 					w.FlipPixel(e.Cell.X, e.Cell.Y)
 				}
-			case gol.TurnComplete:
-				if w != nil {
-					w.RenderFrame()
-				}
-				count := 0
-				for y := 0; y < p.ImageHeight; y++ {
-					for x := 0; x < p.ImageWidth; x++ {
-						if board[y][x] == 255 {
-							count++
-						}
+			case gol.CellsFlipped:
+				cellFlippedReceived = true
+				assert(e.CompletedTurns == tester.turn || e.CompletedTurns == tester.turn+1,
+					"Expected completed %v turns, got %v instead", tester.turn, e.CompletedTurns)
+				for _, cell := range e.Cells {
+					tester.world[cell.Y][cell.X] = ^tester.world[cell.Y][cell.X]
+					if w != nil {
+						w.FlipPixel(cell.X, cell.Y)
 					}
 				}
-				sdlAlive <- count
+			case gol.TurnComplete:
+				turnCompleteReceived = true
+				tester.turn++
+				assert(e.CompletedTurns == tester.turn || e.CompletedTurns == tester.turn+1,
+					"Expected completed %v turns, got %v instead", tester.turn, e.CompletedTurns)
+				tester.testAlive()
+				tester.testGol()
+				if refresh != nil {
+					refresh <- true
+				}
+			case gol.AliveCellsCount:
+				fmt.Printf("Completed Turns %-8v %-20v Avg%+5v turns/sec\n", event.GetCompletedTurns(), event, avgTurns.Get(event.GetCompletedTurns()))
+			case gol.ImageOutputComplete:
+				fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+				eventWatcher <- e
 			case gol.FinalTurnComplete:
-				if w != nil {
-					w.Destroy()
-				}
-				break sdlLoop
-			default:
-				if len(event.String()) > 0 {
-					fmt.Printf("Completed Turns %-8v%v\n", event.GetCompletedTurns(), event)
-				}
+				fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+				eventWatcher <- e
+			case gol.StateChange:
+				fmt.Printf("Completed Turns %-8v %v\n", event.GetCompletedTurns(), event)
+				eventWatcher <- e
 			}
-		default:
-			break
 		}
 	}
-	os.Exit(<-result)
 }
 
-// TestSdl tests a 512x512 image for 100 turns using 8 worker threads.
-func TestSdl(t *testing.T) {
-	p := gol.Params{ImageWidth: 512, ImageHeight: 512, Turns: 100, Threads: 8}
-	testName := fmt.Sprintf("%dx%dx%d-%d", p.ImageWidth, p.ImageHeight, p.Turns, p.Threads)
-	alive := readAliveCounts(p.ImageWidth, p.ImageHeight)
-	t.Run(testName, func(t *testing.T) {
-		turnNum := 0
-		events := make(chan gol.Event)
-		go gol.Run(p, events, nil)
-		time.Sleep(2 * time.Second)
-		final := false
-		for event := range events {
-			switch e := event.(type) {
-			case gol.CellFlipped:
-				sdlEvents <- e
-			case gol.TurnComplete:
-				turnNum++
-				sdlEvents <- e
-				aliveCount := <-sdlAlive
-				if alive[turnNum] != aliveCount {
-					t.Logf("Incorrect number of alive cells displayed on turn %d. Was %d, should be %d.", turnNum, aliveCount, alive[turnNum])
-					time.Sleep(5 * time.Second)
-					sdlEvents <- gol.FinalTurnComplete{}
-					t.FailNow()
-				}
-			case gol.FinalTurnComplete:
-				final = true
-				sdlEvents <- e
+func (tester *Tester) testAlive() {
+	aliveCount := 0
+	for _, row := range tester.world {
+		for _, cell := range row {
+			if cell == 0xFF {
+				aliveCount++
 			}
 		}
+	}
+	expected := 0
+	if tester.turn <= 10000 {
+		expected = tester.aliveMap[tester.turn]
+	} else if tester.turn%2 == 0 {
+		expected = 5565
+	} else {
+		expected = 5567
+	}
+	assert(aliveCount == expected,
+		"At turn %v expected %v alive cells, got %v instead", tester.turn, expected, aliveCount)
+}
 
-		if !final {
-			sdlEvents <- gol.FinalTurnComplete{}
-			t.Fatal("Simulation finished without sending a FinalTurnComplete event.")
+func (tester *Tester) testGol() {
+	if tester.turn == 0 || tester.turn == 1 || tester.turn == 100 {
+		width, height := tester.params.ImageWidth, tester.params.ImageHeight
+		path := fmt.Sprintf("check/images/%vx%vx%v.pgm", width, height, tester.turn)
+		expectedAlive := readAliveCells(path, width, height)
+		aliveCells := make([]util.Cell, 0, width*height)
+		for y := range tester.world {
+			for x, cell := range tester.world[y] {
+				if cell == 255 {
+					aliveCells = append(aliveCells, util.Cell{X: x, Y: y})
+				}
+			}
 		}
-	})
+		assertEqualBoard(tester.t, aliveCells, expectedAlive, tester.params)
+	}
+}
+
+func (tester *Tester) testOutput(delay time.Duration) {
+	time.Sleep(delay)
+	width, height := tester.params.ImageWidth, tester.params.ImageHeight
+	tester.t.Logf("Testing image output")
+	for len(tester.eventWatcher) > 0 {
+		<-tester.eventWatcher
+	}
+	tester.keyPresses <- 's'
+	timeout(4*time.Second, func() {
+		for e := range tester.eventWatcher {
+			if e, ok := e.(gol.ImageOutputComplete); ok {
+				assert(e.Filename == fmt.Sprintf("%vx%vx%v", width, height, e.CompletedTurns),
+					"Filename is not correct")
+				break
+			}
+		}
+	}, "No ImageOutput events received in 4 seconds\n%v",
+		"If this test is running in WSL2, please make sure the test is located within WSL2 file system rather than Windows! i.e. Your path must not start with /mnt/...")
+}
+
+func (tester *Tester) testPause(delay time.Duration) {
+	time.Sleep(delay)
+	tester.t.Logf("Testing Pause key pressed")
+	for len(tester.eventWatcher) > 0 {
+		<-tester.eventWatcher
+	}
+	tester.keyPresses <- 'p'
+	timeout(2*time.Second, func() {
+		for e := range tester.eventWatcher {
+			if e, ok := e.(gol.StateChange); ok && e.NewState == gol.Paused {
+				break
+			}
+		}
+	}, "No Pause events received in 2 seconds")
+
+	tester.testOutput(2 * time.Second)
+
+	time.Sleep(2 * time.Second)
+	tester.t.Logf("Testing Pause key pressed again")
+	tester.keyPresses <- 'p'
+	timeout(2*time.Second, func() {
+		for e := range tester.eventWatcher {
+			if e, ok := e.(gol.StateChange); ok && e.NewState == gol.Executing {
+				break
+			}
+		}
+	}, "No Executing events received in 2 seconds")
+}
+
+func (tester *Tester) testQuitting(delay time.Duration) {
+	time.Sleep(delay)
+	tester.t.Logf("Testing Quit key pressed")
+	for len(tester.eventWatcher) > 0 {
+		<-tester.eventWatcher
+	}
+	tester.keyPresses <- 'q'
+	timeout(2*time.Second, func() {
+		for e := range tester.eventWatcher {
+			if _, ok := e.(gol.FinalTurnComplete); ok {
+				break
+			}
+		}
+	}, "No FinalTurnComplete events received in 2 seconds")
+
+	timeout(4*time.Second, func() {
+		for e := range tester.eventWatcher {
+			if _, ok := e.(gol.ImageOutputComplete); ok {
+				break
+			}
+		}
+	}, "No ImageOutput events received in 4 seconds")
+
+	timeout(2*time.Second, func() {
+		for e := range tester.eventWatcher {
+			if e, ok := e.(gol.StateChange); ok && e.NewState == gol.Quitting {
+				break
+			}
+		}
+	}, "No Quitting events received in 2 seconds")
+}
+
+func deadline(ddl time.Duration, msg string) chan<- bool {
+	done := make(chan bool, 1)
+	go func() {
+		select {
+		case <-time.After(ddl):
+			panic(msg)
+		case <-done:
+			return
+		}
+	}()
+	return done
+}
+
+func timeout(ddl time.Duration, f func(), msg string, a ...any) {
+	done := make(chan bool, 1)
+	go func() {
+		f()
+		done <- true
+	}()
+	select {
+	case <-time.After(ddl):
+		panic(fmt.Sprintf(msg, a...))
+	case <-done:
+		break
+	}
+}
+
+func assert(predicate bool, msg string, a ...any) {
+	if !predicate {
+		panic(fmt.Sprintf(msg, a...))
+	}
 }

--- a/util/avgturns.go
+++ b/util/avgturns.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"math"
+	"time"
+)
+
+const BUF_SIZE = 3
+
+type AvgTurns struct {
+	count             int
+	lastCompleteTurns int
+	lastCalled        time.Time
+	bufTurns          [BUF_SIZE]int
+	bufDurations      [BUF_SIZE]time.Duration
+}
+
+func NewAvgTurns() *AvgTurns {
+	return &AvgTurns{
+		count:             0,
+		lastCompleteTurns: 0,
+		lastCalled:        time.Now(),
+		bufTurns:          [BUF_SIZE]int {},
+		bufDurations:      [BUF_SIZE]time.Duration {},
+	}
+}
+
+func (avg *AvgTurns) Get(completedTurns int) int {
+	avg.bufTurns[avg.count%BUF_SIZE] = completedTurns - avg.lastCompleteTurns
+	avg.bufDurations[avg.count%BUF_SIZE] = time.Since(avg.lastCalled)
+	avg.lastCalled = time.Now()
+	avg.lastCompleteTurns = completedTurns
+	avg.count++
+	sumTurns := 0
+	for _, turns := range avg.bufTurns {
+		sumTurns += turns
+	}
+	sumDurations := time.Duration(0)
+	for _, durations := range avg.bufDurations {
+		sumDurations += durations
+	}
+	return int(sumTurns) / int(math.Round(sumDurations.Seconds()))
+}


### PR DESCRIPTION
Some major changes

* Bump go-sdl2 to 0.4.38 to remove deprecated api calls

* Update the minimum supported golang version to 1.21

* Add average turns calculation 
  (will notice students in the updated instruction that using it for performance metrics is not allowed in their reports, or shall we just remove this feature? @TBExtent)

* Capturing SIGTERM and SIGINT for graceful termination
  The program now captures CTRL+C in the terminal then send 'q' to distributor, it is useful in a headless environment.

* Rewrite the loop for polling sdl and gol events
  The old spinning loop doesn't yield cpu time and cause event channel blocking, the new implementation incurs no performance loss for visualisation.

* Add new `CellsFlipped` event

  This is the introduction for `CellsFlipped` in event.go:
  > `CellsFlipped` is an Event notifying the GUI about a change of state of many cells.
  > You can collect many flipped cells and send `CellsFlipped` at a time instead of sending `CellFlipped` for every flipped cell.
  > You can send many times of `CellsFlipped` event in a turn, i.e., each worker could send `CellsFlipped`.
  > **Please be careful not to send `CellFlipped` and `CellsFlipped` at the same time, as they may conflict.**
  > Choose one of them.

* Rewrite SDL test: testing Gol and AliveCount and all events at the same time, and the test can also determine whether the program terminates after the QUIT event is sent.

  To run the new test, type `go test -v -run TestSdl`, to test with visualisation with SDL, type `go test -v -run TestSdl -sdl`

  To pass the new SDL test, students' implementation should follow the new rules when `q` is pressed:

  > Complete current turn and send a `TurnComplete` event -> Send a `FinalTurnComplete` event -> Save the final state as PGM image and send an `ImageOutputComplete` event -> Send a `StateChange` event and terminate

  Also, it is **necessary** for q and s to work while the execution is paused from now on.

  *These rules will be included in the updated instructions later.*

  I have tested the robustness of the new test on WSL2, native Windows, and macOS, it works fine. Further testing with the automarker is necessary, can you help with this? @TBExtent thanks.
